### PR TITLE
Update alerts.yaml

### DIFF
--- a/charts/cnp-sandbox/alerts.yaml
+++ b/charts/cnp-sandbox/alerts.yaml
@@ -33,7 +33,7 @@ groups:
       description: Standby is lagging behind by over 300 seconds (5 minutes)
       summary: The standby is lagging behind the primary
     expr: |-
-      cnp_pg_database_xid_age > 150000000
+      cnp_pg_replication_lag > 300
     for: 1m
     labels:
       severity: warning


### PR DESCRIPTION
The default Replication Lag [alerts](https://github.com/EnterpriseDB/cnp-sandbox/blob/main/charts/cnp-sandbox/alerts.yaml) is using the expression for transaction id age rather cnp_replication_lag. 

Current on main: 
```
  - alert: PGReplication
    annotations:
      description: Standby is lagging behind by over 300 seconds (5 minutes)
      summary: The standby is lagging behind the primary
    expr: |-
      cnp_pg_database_xid_age > 150000000
    for: 1m
    labels:
      severity: warning 
```

Should be:
```
- alert: PGReplication
    annotations:
      description: Standby is lagging behind by over 300 seconds (5 minutes)
      summary: The standby is lagging behind the primary
    expr: |-
      cnp_replication_lag > 300
    for: 1m
    labels:
      severity: warning
```